### PR TITLE
Feature#11 Progress Bar: API ; UI; Template usage; Implementation in Minigame 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "test": "vitest"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { ProgressStatus } from '../../types/Minigame';
+import './styles.css';
+
+export interface ProgressBarProps {
+  total: number;
+  statuses: ProgressStatus[];
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ total, statuses }) => {
+  if (total === 0) return null;
+  const resolved =
+    statuses.length >= total
+      ? statuses
+      : (Array(total).fill('pending').slice(0, total) as ProgressStatus[]);
+  return (
+    <div
+      className="progress-bar"
+      role="progressbar"
+      aria-valuenow={resolved.filter((s) => s !== 'pending').length}
+      aria-valuemin={0}
+      aria-valuemax={total}
+    >
+      {resolved.map((status, i) => (
+        <span
+          key={i}
+          className={`progress-dot progress-dot--${status}`}
+          data-state={status}
+          data-index={i}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -7,12 +7,18 @@ export interface ProgressBarProps {
   statuses: ProgressStatus[];
 }
 
+/**
+ * Ensures the statuses array has exactly `total` entries.
+ * Pads with 'pending' if shorter; truncates if longer.
+ */
+function ensureStatusesArray(total: number, statuses: ProgressStatus[]): ProgressStatus[] {
+  if (statuses.length >= total) return statuses.slice(0, total);
+  return [...statuses, ...Array<ProgressStatus>(total - statuses.length).fill('pending')];
+}
+
 const ProgressBar: React.FC<ProgressBarProps> = ({ total, statuses }) => {
   if (total === 0) return null;
-  const resolved =
-    statuses.length >= total
-      ? statuses
-      : (Array(total).fill('pending').slice(0, total) as ProgressStatus[]);
+  const resolved = ensureStatusesArray(total, statuses);
   return (
     <div
       className="progress-bar"

--- a/src/components/ProgressBar/styles.css
+++ b/src/components/ProgressBar/styles.css
@@ -1,0 +1,25 @@
+.progress-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.progress-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  transition: background-color 0.2s ease;
+}
+
+.progress-dot--pending {
+  background-color: #ccc;
+}
+
+.progress-dot--correct {
+  background-color: #22c55e;
+}
+
+.progress-dot--incorrect {
+  background-color: #ef4444;
+}

--- a/src/minigames/index.ts
+++ b/src/minigames/index.ts
@@ -2,6 +2,8 @@ import Minigame1, { metadata as meta1 } from './minigame1-scholarship';
 import Minigame2, { metadata as meta2 } from './minigame2-budgeting';
 import Minigame3, { metadata as meta3 } from './minigame3-saving';
 import Minigame4, { metadata as meta4 } from './minigame4-investing';
+//this is the template minigame, used as testing playground
+import Minigame5, {metadata as meta5} from './template';
 import type { ComponentType } from "react";
 import type { MinigameProps } from "../types/Minigame";
 
@@ -15,12 +17,16 @@ export interface MinigameConfig {
   };
 }
 
+
 // Plugin Registry - maps level IDs to minigame configs
 export const MINIGAMES: Record<string, MinigameConfig> = {
   'level-1': { Component: Minigame1, metadata: meta1 },
   'level-2': { Component: Minigame2, metadata: meta2 },
   'level-3': { Component: Minigame3, metadata: meta3 },
   'level-4': { Component: Minigame4, metadata: meta4 },
+  //this is the teamplate minigame, used as testing playground
+  //could be commented out later
+  'level-5': { Component: Minigame5, metadata: meta5 },
 };
 
 //could use this to hold general UI logic (progress bar, notification pop-ups)

--- a/src/minigames/minigame2-budgeting/budget-game-setup.ts
+++ b/src/minigames/minigame2-budgeting/budget-game-setup.ts
@@ -1,8 +1,9 @@
 import { useCalendarLogic } from "./calendar-logic"; // button logic
 import { useQuestionLogic } from "./question-logic"; // question logic
 import { useState } from "react"; // ties logic together for actual game
+import type { ProgressApi } from "../../types/Minigame";
 
-export const useBudgetGameLogic = () => {
+export const useBudgetGameLogic = (progressApi?: ProgressApi) => {
   //game logic set-up
   const {workDays, totalWorkDays, toggleDay, resetButtons} = useCalendarLogic(5);
   const {currentQuestion, nextQuestion, questionCount} = useQuestionLogic();
@@ -25,10 +26,14 @@ export const useBudgetGameLogic = () => {
     if (isCorrect){
       alert("Correct! Insert Correct Pop-up here!")
       setProgress(prev => ({...prev, correct: prev.correct + 1}));
+      // if correct, mark question as correct
+      progressApi?.markCorrect(currentQuestion.id - 1);
     }else{
       const difference = currentQuestion.answer - currentIncome;
       alert(`Close but not correct. You are ${Math.abs(difference)} coins$ off. Let's try on the next one! (Insert incorrect pop-up here)`)
       setProgress(prev => ({...prev, incorrect: prev.incorrect + 1}));
+      // if incorrect, mark question as incorrect
+      progressApi?.markIncorrect(currentQuestion.id - 1);
     }
     //resets buttons and goes to next question
     nextQuestion();
@@ -45,7 +50,7 @@ export const useBudgetGameLogic = () => {
     currentQuestion,
     currentIncome,
     submitAnswer,
+    questionCount, // for progress bar initialization
     progress //for tests
-
   };
 };

--- a/src/minigames/minigame2-budgeting/budget-game-setup.ts
+++ b/src/minigames/minigame2-budgeting/budget-game-setup.ts
@@ -26,13 +26,15 @@ export const useBudgetGameLogic = (progressApi?: ProgressApi) => {
     if (isCorrect){
       alert("Correct! Insert Correct Pop-up here!")
       setProgress(prev => ({...prev, correct: prev.correct + 1}));
-      // if correct, mark question as correct
+      // Mark question as correct. currentQuestion.id is 1-based;
+      // subtract 1 to convert to 0-based index for progress API.
       progressApi?.markCorrect(currentQuestion.id - 1);
     }else{
       const difference = currentQuestion.answer - currentIncome;
       alert(`Close but not correct. You are ${Math.abs(difference)} coins$ off. Let's try on the next one! (Insert incorrect pop-up here)`)
       setProgress(prev => ({...prev, incorrect: prev.incorrect + 1}));
-      // if incorrect, mark question as incorrect
+      // Mark question as incorrect. currentQuestion.id is 1-based;
+      // subtract 1 to convert to 0-based index for progress API.
       progressApi?.markIncorrect(currentQuestion.id - 1);
     }
     //resets buttons and goes to next question

--- a/src/minigames/minigame2-budgeting/index.tsx
+++ b/src/minigames/minigame2-budgeting/index.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import CalendarButton from './calendar-button'; //buttons for interactive counter
 // import { useCalendarLogic } from './calendar-logic'; //math logic for interactive counter
 // import { useQuestionLogic } from './question-logic'; // question load / check answer
 import QuestionDisplay from './question-display'; // question view
 import { useBudgetGameLogic } from './budget-game-setup';
+import type { MinigameProps } from '../../types/Minigame';
 import './styles.css';
 
 export const metadata = {
@@ -12,7 +13,8 @@ export const metadata = {
   id: "level-2"
 };
 
-const Minigame2: React.FC = () => {
+// pass progress api to the minigame
+const Minigame2: React.FC<MinigameProps> = ({ progress }) => {
   //set-up everything from useBudgetGameLogic
   const {
     workDays,
@@ -20,8 +22,15 @@ const Minigame2: React.FC = () => {
     totalWorkDays,
     currentQuestion,
     currentIncome,
-    submitAnswer
-  } = useBudgetGameLogic();
+    submitAnswer,
+    // get total number of questions
+    questionCount
+  } = useBudgetGameLogic(progress);
+
+  // initialize progress bar with total number of questions
+  useEffect(() => {
+    progress?.init(questionCount);
+  }, [progress, questionCount]);
 
   //helper function: set up the calendar views to be placed in corners of the buttons
   const renderCalendarButton = (isWork: boolean, index: number) => {

--- a/src/minigames/template/index.tsx
+++ b/src/minigames/template/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import './styles.css';
+
+export const metadata = {
+  title: "Template",
+  description: "Placeholder.",
+  id: "level-5"
+};
+
+const Minigame5: React.FC = () => {
+  return (
+    <div className="minigame-level4-container">
+      <h1 style={{ fontSize: '3rem', marginBottom: '2rem' }}>Hi! I'm Template</h1>
+      <p style={{ fontSize: '1.5rem', color: '#666' }}>Template Game Loaded ✓</p>
+    </div>
+  );
+};
+
+export default Minigame5;

--- a/src/minigames/template/index.tsx
+++ b/src/minigames/template/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import type { MinigameProps } from '../../types/Minigame';
 import './styles.css';
 
 export const metadata = {
@@ -7,11 +8,39 @@ export const metadata = {
   id: "level-5"
 };
 
-const Minigame5: React.FC = () => {
+const TOTAL_QUESTIONS = 5;
+
+const Minigame5: React.FC<MinigameProps> = ({ progress }) => {
+  useEffect(() => {
+    progress?.init(TOTAL_QUESTIONS);
+  }, [progress]);
+
   return (
     <div className="minigame-level4-container">
       <h1 style={{ fontSize: '3rem', marginBottom: '2rem' }}>Hi! I'm Template</h1>
-      <p style={{ fontSize: '1.5rem', color: '#666' }}>Template Game Loaded ✓</p>
+      <p style={{ fontSize: '1.5rem', color: '#666', marginBottom: '2rem' }}>
+        ProgressBar demo: 5 dots at the top. Use the buttons below to mark each as correct (green) or incorrect (red).
+      </p>
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', justifyContent: 'center' }}>
+        {Array.from({ length: TOTAL_QUESTIONS }, (_, i) => (
+          <span key={i} style={{ display: 'flex', gap: '0.25rem' }}>
+            <button
+              type="button"
+              onClick={() => progress?.markCorrect(i)}
+              style={{ padding: '0.5rem 0.75rem', cursor: 'pointer' }}
+            >
+              {i + 1}✓
+            </button>
+            <button
+              type="button"
+              onClick={() => progress?.markIncorrect(i)}
+              style={{ padding: '0.5rem 0.75rem', cursor: 'pointer' }}
+            >
+              {i + 1}✗
+            </button>
+          </span>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/minigames/template/index.tsx
+++ b/src/minigames/template/index.tsx
@@ -16,7 +16,7 @@ const Minigame5: React.FC<MinigameProps> = ({ progress }) => {
   }, [progress]);
 
   return (
-    <div className="minigame-level4-container">
+    <div className="template-container">
       <h1 style={{ fontSize: '3rem', marginBottom: '2rem' }}>Hi! I'm Template</h1>
       <p style={{ fontSize: '1.5rem', color: '#666', marginBottom: '2rem' }}>
         ProgressBar demo: 5 dots at the top. Use the buttons below to mark each as correct (green) or incorrect (red).

--- a/src/minigames/template/styles.css
+++ b/src/minigames/template/styles.css
@@ -1,0 +1,21 @@
+.template-container {
+    background-color: #FFFFFF; /* Purple 100 - More distinct */
+    width: 100%;
+    height: 100%;
+    
+    /* Reset Frame Styles */
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    margin: 0;
+    max-width: none;
+    max-height: none;
+    aspect-ratio: auto;
+  
+    /* Internal Layout */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  

--- a/src/pages/MinigamePage/index.tsx
+++ b/src/pages/MinigamePage/index.tsx
@@ -4,12 +4,14 @@ import { MINIGAMES } from "../../minigames";
 import MinigameEnd from "../../minigames/minigame-end";
 import type { MinigameResult } from "../../types/Minigame";
 import { StarsProvider } from "../MapPage/Stars";
+import { useProgressState } from "./useProgressState";
 import './styles.css';
 
 const MinigamePage: React.FC = () => {
   const [result, setResult] = useState<MinigameResult | null>(null);
   const { levelId } = useParams<{ levelId: string }>();
   const navigate = useNavigate();
+  const { progressApi } = useProgressState();
 
   const handleBackToMap = () => {
     console.log("Back Button Pressed");
@@ -41,8 +43,8 @@ const MinigamePage: React.FC = () => {
         </div>
 
         <div className="minigame-content">
-          {MinigameComponent ? (
-            <MinigameComponent onComplete={handleMinigameComplete} />
+          {MinigameComponent ? ( // minigame component uses progress api
+            <MinigameComponent onComplete={handleMinigameComplete} progress={progressApi} />
           ) : (
             <h1>Error: Minigame not found</h1>
           )}

--- a/src/pages/MinigamePage/index.tsx
+++ b/src/pages/MinigamePage/index.tsx
@@ -5,13 +5,14 @@ import MinigameEnd from "../../minigames/minigame-end";
 import type { MinigameResult } from "../../types/Minigame";
 import { StarsProvider } from "../MapPage/Stars";
 import { useProgressState } from "./useProgressState";
+import ProgressBar from "../../components/ProgressBar";
 import './styles.css';
 
 const MinigamePage: React.FC = () => {
   const [result, setResult] = useState<MinigameResult | null>(null);
   const { levelId } = useParams<{ levelId: string }>();
   const navigate = useNavigate();
-  const { progressApi } = useProgressState();
+  const { progressState, progressApi } = useProgressState();
 
   const handleBackToMap = () => {
     console.log("Back Button Pressed");
@@ -40,6 +41,15 @@ const MinigamePage: React.FC = () => {
           <button className="back-button" onClick={handleBackToMap}>
             ←
           </button>
+
+          {/* progress bar will be shown only when there are questions */}
+          <div className="minigame-header-center">
+            {progressState.total > 0 && (
+              <ProgressBar total={progressState.total} statuses={progressState.statuses} />
+            )}
+          </div>
+          {/* spacer to separate buttons from progress bar */}
+          <div className="minigame-header-spacer" aria-hidden="true" />
         </div>
 
         <div className="minigame-content">

--- a/src/pages/MinigamePage/index.tsx
+++ b/src/pages/MinigamePage/index.tsx
@@ -1,3 +1,4 @@
+// Minigame page: loads level, shows progress bar, passes progress API to minigame.
 import React, { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { MINIGAMES } from "../../minigames";

--- a/src/pages/MinigamePage/styles.css
+++ b/src/pages/MinigamePage/styles.css
@@ -11,10 +11,30 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
   padding: 1.5rem;
   background: transparent;
   border: none;
   z-index: 100; /* Ensure button is above game */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* progress bar wrapper */
+.minigame-header-center {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* spacer to separate buttons from progress bar */
+.minigame-header-spacer {
+  width: 6rem;
+  flex-shrink: 0;
 }
 
 .back-button {

--- a/src/pages/MinigamePage/useProgressState.ts
+++ b/src/pages/MinigamePage/useProgressState.ts
@@ -1,0 +1,58 @@
+import { useState, useMemo, useRef } from 'react';
+import type { ProgressState, ProgressApi } from '../../types/Minigame';
+
+// initial progress stae - zero questions, zero statuses
+const initialProgressState: ProgressState = { total: 0, statuses: [] };
+
+export function useProgressState() {
+  const [progressState, setProgressState] = useState<ProgressState>(initialProgressState);
+  const stateRef = useRef(progressState);
+  stateRef.current = progressState;
+
+  const progressApi: ProgressApi = useMemo(
+    () => ({
+
+      // initialize progress bar 
+      init(total: number) {
+        setProgressState({
+          total, // total no. of questions 
+          statuses: Array(total).fill('pending') as ProgressState['statuses'], // init all questions as pending state
+        });
+      },
+
+      // api to mark question as correct
+      markCorrect(index: number) {
+        if (index < 0) return; 
+        setProgressState((prev) => ({ 
+          ...prev,  // save previous state
+          statuses: prev.statuses.map((s, j) => (j === index ? 'correct' : s)),// update question at index to correct state
+        }));
+      },
+
+      // api to mark question as incorrect
+      markIncorrect(index: number) {
+        if (index < 0) return;
+        setProgressState((prev) => ({
+          ...prev,
+          statuses: prev.statuses.map((s, j) => (j === index ? 'incorrect' : s)),
+        }));
+      },
+
+      // reset progress bar 
+      // useful for restarting game
+      // can also be used to reset progress bar (quit and restart)
+      reset() {
+        setProgressState(initialProgressState);
+      },
+
+      //get current progress state
+      //return format: {total: number, statuses: ProgressStatus[]}
+      getProgress() {
+        return stateRef.current;
+      },
+    }),
+    []
+  );
+
+  return { progressState, progressApi };
+}

--- a/src/pages/MinigamePage/useProgressState.ts
+++ b/src/pages/MinigamePage/useProgressState.ts
@@ -1,3 +1,4 @@
+// Progress bar state and API for minigame page (init / markCorrect / markIncorrect).
 import { useState, useMemo, useRef } from 'react';
 import type { ProgressState, ProgressApi } from '../../types/Minigame';
 
@@ -20,18 +21,18 @@ export function useProgressState() {
         });
       },
 
-      // api to mark question as correct
+      // api to mark question as correct (0-based index)
       markCorrect(index: number) {
-        if (index < 0) return; 
+        if (index < 0 || index >= stateRef.current.total) return; 
         setProgressState((prev) => ({ 
           ...prev,  // save previous state
           statuses: prev.statuses.map((s, j) => (j === index ? 'correct' : s)),// update question at index to correct state
         }));
       },
 
-      // api to mark question as incorrect
+      // api to mark question as incorrect (0-based index)
       markIncorrect(index: number) {
-        if (index < 0) return;
+        if (index < 0 || index >= stateRef.current.total) return;
         setProgressState((prev) => ({
           ...prev,
           statuses: prev.statuses.map((s, j) => (j === index ? 'incorrect' : s)),

--- a/src/tests/ProgressBar.test.tsx
+++ b/src/tests/ProgressBar.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { ProgressStatus } from '../types/Minigame';
+import ProgressBar from '../components/ProgressBar';
+
+describe('ProgressBar', () => {
+  it('renders nothing when total is 0', () => {
+    const { container } = render(<ProgressBar total={0} statuses={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders 5 dots when total=5 and all pending', () => {
+    const statuses: ProgressStatus[] = ['pending', 'pending', 'pending', 'pending', 'pending'];
+    render(<ProgressBar total={5} statuses={statuses} />);
+    const dots = document.querySelectorAll('.progress-dot');
+    expect(dots).toHaveLength(5);
+    dots.forEach((dot) => expect(dot).toHaveAttribute('data-state', 'pending'));
+  });
+
+  it('renders correct and incorrect states on the right dots', () => {
+    const statuses: ProgressStatus[] = ['correct', 'incorrect', 'pending'];
+    render(<ProgressBar total={3} statuses={statuses} />);
+    const dots = document.querySelectorAll('.progress-dot');
+    expect(dots).toHaveLength(3);
+    expect(dots[0]).toHaveAttribute('data-state', 'correct');
+    expect(dots[0]).toHaveClass('progress-dot--correct');
+    expect(dots[1]).toHaveAttribute('data-state', 'incorrect');
+    expect(dots[1]).toHaveClass('progress-dot--incorrect');
+    expect(dots[2]).toHaveAttribute('data-state', 'pending');
+    expect(dots[2]).toHaveClass('progress-dot--pending');
+  });
+});

--- a/src/tests/character.test.tsx
+++ b/src/tests/character.test.tsx
@@ -1,6 +1,7 @@
 import {fireEvent, render, screen} from "@testing-library/react";
 import {describe, it, expect} from "vitest";
-import ScholarshipCharacter from "./character";
+import "@testing-library/jest-dom";
+import ScholarshipCharacter from "../minigames/minigame1-scholarship/character"; 
 
 
  describe("ScholarshipCharacter", () => {

--- a/src/tests/useProgressState.test.ts
+++ b/src/tests/useProgressState.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useProgressState } from '../pages/MinigamePage/useProgressState';
+
+describe('useProgressState', () => {
+
+  //test 1 : no questions, no statuses
+  it('initial state has total 0 and empty statuses', () => {
+    const { result } = renderHook(() => useProgressState());
+    expect(result.current.progressState.total).toBe(0);
+    expect(result.current.progressState.statuses).toEqual([]);
+  });
+
+ //test 2: initialization 
+  it('init(3) sets total to 3 and statuses to three pendings', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(3);
+    });
+    expect(result.current.progressState.total).toBe(3);
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending', 'pending']);
+  });
+
+  //test 3: mark correct
+  it('markCorrect(0) sets first question to correct', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(3);
+    });
+    act(() => {
+      // please notice the index of first question is 0
+      result.current.progressApi.markCorrect(0);
+    });
+    expect(result.current.progressState.statuses[0]).toBe('correct');
+    expect(result.current.progressState.statuses[1]).toBe('pending');
+    expect(result.current.progressState.statuses[2]).toBe('pending');
+  });
+
+  // test 4: mark incorrect
+  it('markIncorrect(1) sets second question to incorrect', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(3);
+    });
+    act(() => {
+      result.current.progressApi.markIncorrect(1);
+    });
+    expect(result.current.progressState.statuses[0]).toBe('pending');
+    expect(result.current.progressState.statuses[1]).toBe('incorrect');
+    expect(result.current.progressState.statuses[2]).toBe('pending');
+  });
+
+  // test 5: co-existance of mark correct/incorrect 
+  it('markCorrect and markIncorrect can be used together', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(3);
+    });
+    act(() => {
+      result.current.progressApi.markCorrect(0);
+      result.current.progressApi.markIncorrect(1);
+    });
+    expect(result.current.progressState.statuses[0]).toBe('correct');
+    expect(result.current.progressState.statuses[1]).toBe('incorrect');
+    expect(result.current.progressState.statuses[2]).toBe('pending');
+  });
+
+  // test 6: mark correct with invalid index
+  it('markCorrect(-1) does not throw and does not change state', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(2);
+    });
+    act(() => {
+      result.current.progressApi.markCorrect(-1);
+    });
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending']);
+  });
+
+  // test 7: mark incorrect with invalid index
+  it('markIncorrect(-1) does not throw and does not change state', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(2);
+    });
+    act(() => {
+      result.current.progressApi.markIncorrect(-1);
+    });
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending']);
+  });
+
+  // test 8: reset progress bar
+  it('reset() restores initial state', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(3);
+      result.current.progressApi.markCorrect(0);
+    });
+    act(() => {
+      result.current.progressApi.reset();
+    });
+    expect(result.current.progressState.total).toBe(0);
+    expect(result.current.progressState.statuses).toEqual([]);
+  });
+
+  // test 9: get current progress state
+  it('getProgress() returns current progress state', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(2);
+    });
+    const state = result.current.progressApi.getProgress();
+    expect(state.total).toBe(2);
+    expect(state.statuses).toEqual(['pending', 'pending']);
+    act(() => {
+      result.current.progressApi.markCorrect(0);
+    });
+    const stateAfter = result.current.progressApi.getProgress();
+    expect(stateAfter.statuses[0]).toBe('correct');
+  });
+});

--- a/src/tests/useProgressState.test.ts
+++ b/src/tests/useProgressState.test.ts
@@ -1,3 +1,4 @@
+// Tests for progress bar API (useProgressState hook).
 import { describe, it, expect } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useProgressState } from '../pages/MinigamePage/useProgressState';
@@ -117,5 +118,37 @@ describe('useProgressState', () => {
     });
     const stateAfter = result.current.progressApi.getProgress();
     expect(stateAfter.statuses[0]).toBe('correct');
+  });
+
+  // test 10: markCorrect with out-of-bounds index (>= total)
+  it('markCorrect with index >= total does not change state', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(2);
+    });
+    act(() => {
+      result.current.progressApi.markCorrect(2); // index === total
+    });
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending']);
+    act(() => {
+      result.current.progressApi.markCorrect(5); // index > total
+    });
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending']);
+  });
+
+  // test 11: markIncorrect with out-of-bounds index (>= total)
+  it('markIncorrect with index >= total does not change state', () => {
+    const { result } = renderHook(() => useProgressState());
+    act(() => {
+      result.current.progressApi.init(2);
+    });
+    act(() => {
+      result.current.progressApi.markIncorrect(2); // index === total
+    });
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending']);
+    act(() => {
+      result.current.progressApi.markIncorrect(10); // index > total
+    });
+    expect(result.current.progressState.statuses).toEqual(['pending', 'pending']);
   });
 });

--- a/src/types/Minigame.ts
+++ b/src/types/Minigame.ts
@@ -4,10 +4,36 @@ export interface MinigameResult {
 
 export interface MinigameProps {
   onComplete: (result: MinigameResult) => void;
+  progress?: ProgressApi;
 }
 
 export type StarsContextValue = {
   stars: number;
   addStars: (earned: number) => void;
 };
+
+// three possible question statuses
+export type ProgressStatus = 'pending' | 'correct' | 'incorrect';
+
+
+// progress bar interface
+export interface ProgressState {
+  //total number of questions 
+  total: number;
+  // array to store question index and status
+  statuses: ProgressStatus[]; 
+}
+
+//progress bar api; 
+
+export interface ProgressApi{
+  // dynamic init given number of questions 
+  init: (total:number) => void;
+  markCorrect: (index:number) => void;
+  markIncorrect: (index:number) => void;
+  //reset progress (if needed)
+  reset: () => void;
+  //get current progress state
+  getProgress: () => ProgressState;
+}
 

--- a/src/types/Minigame.ts
+++ b/src/types/Minigame.ts
@@ -1,3 +1,4 @@
+// Minigame types and progress bar API (ProgressApi, ProgressState).
 export interface MinigameResult {
   stars: number;
 }


### PR DESCRIPTION
This is the PR for progress bar

I implemented it in this order ( shown in commit history and relative comments as well ):

first - created testing playground by introducing the template page as a mini- game  ( this could be kept as playground for many more components to come, and removing it is easy, just comment out the reference in minigamepage)

then - implemented progress bar api and tested it out; the api is easy to understand: init with total number of questions (hence dynamic); each question has a index ( start from 0) and three states ( pending | correct | incorrect ); and, given question index, markCorrect set the state from pending to correct , vice versa

then - implemented and tested progress bar UI in components following Faith's design -- grey | green | red 

then - provided a demo of progress bar usage in template mini-game so people working on their games could refer to

then - with 8 lines of code, extended mini-game 2 to use the progress bar ; I was hesitant to do this since it'd introduce possible conflicts, but since max asked me to try out progress bar in game 2, here we go


PS:

1. Why PR'ing this into pr-base : my bad, accidentally pushed the first three (map, nit, progress-bar api) into dev, although reverted it, it left a record, and it won't show the difference in pr from map_dev to dev on github although there's still difference in git ( i blame github for this ) , so pr-base was basically a copy dev before my pushes.
2. What to do after: after people reviewed and approved this, i'm going to merge pr-base into dev ( it's the same as pr'ing from map_dev to dev, but again, github won't show the full file differences)
3. edited package json to remove duplicated import
